### PR TITLE
Refine mobile UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,16 +9,19 @@
 </head>
 <body>
 
+    <!-- New top bar for mobile-style icons -->
+    <div id="top-bar">
+        <!-- ADDED: Help and settings icons moved here -->
+        <button id="help-button" title="How to Play">?</button>
+        <button id="settings-button" title="Settings">⚙</button>
+    </div>
+
     <div id="game-container">
-        <h1>Crossword</h1>
         <div id="stats-container">
              <p id="info-text"></p> <!-- MODIFIED: Text will be set by JS -->
              <div id="game-stats">
                 <span>Guesses: <strong id="guess-count">0</strong></span>
                 <button id="hint-button">Hint (<span id="hints-remaining">0</span>)</button>
-                <!-- ADDED: Help button -->
-                <button id="help-button" title="How to Play">?</button>
-                <button id="settings-button" title="Settings">⚙</button>
              </div>
         </div>
         <div id="grid-container"></div>

--- a/style.css
+++ b/style.css
@@ -36,6 +36,17 @@ body {
     box-sizing: border-box;
 }
 
+/* New top bar for mobile layout */
+#top-bar {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 15px;
+    margin-bottom: 10px;
+    box-sizing: border-box;
+}
+
 #game-container {
     text-align: center;
 }
@@ -310,7 +321,6 @@ body {
     :root {
         --cell-size: 75px; 
     }
-    #game-container h1 { font-size: 1.5rem; }
     .cell { font-size: 3.5rem; }
     #keyboard button { height: 50px; }
     #win-message h2 { font-size: 4rem; }


### PR DESCRIPTION
## Summary
- move help/settings buttons into a new top bar
- remove the Crossword heading
- tweak CSS for the new top bar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f4efaa2c4832da6d5c968be1ae52a