### PR TITLE
Add 4DOWN branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8">
     <!-- MODIFIED: Added maximum-scale=1 to prevent iOS zoom on input focus -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1">
-    <title>HTML Crossword</title>
+    <title>4DOWN</title>
+    <link rel="icon" href="4DOWN-icon.png">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -15,6 +16,8 @@
         <button id="help-button" title="How to Play">?</button>
         <button id="settings-button" title="Settings">⚙</button>
     </div>
+
+    <img id="game-logo" src="4DOWN-small.png" alt="4DOWN logo">
 
     <div id="game-container">
         <div id="stats-container">
@@ -92,7 +95,7 @@
     <div id="help-overlay" class="hidden">
         <div id="help-content">
             <button id="close-help-button">×</button>
-            <h2>How to Play: HTML Crossword</h2>
+            <h2>How to Play: 4DOWN</h2>
             <p>The objective is to fill the 4x4 grid with letters, creating four valid 4-letter words across and four down.</p>
             
             <h3>1. Grid Cell Colors: Your Local Clues</h3>

--- a/script.js
+++ b/script.js
@@ -537,7 +537,7 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // --- ADDED: Share Button Listener ---
     shareButton.addEventListener('click', () => {
-        const shareText = `I solved the HTML Crossword in ${state.guessCount} guesses! 🧩\n\nTry it yourself!`;
+        const shareText = `I solved 4DOWN in ${state.guessCount} guesses! 🧩\n\nTry it yourself!`;
         
         navigator.clipboard.writeText(shareText).then(() => {
             const originalText = shareButton.textContent;

--- a/style.css
+++ b/style.css
@@ -47,6 +47,12 @@ body {
     box-sizing: border-box;
 }
 
+#game-logo {
+    width: 150px;
+    height: auto;
+    margin-bottom: 10px;
+}
+
 #game-container {
     text-align: center;
 }
@@ -319,7 +325,7 @@ body {
 /* --- Responsive Design for Mobile --- */
 @media (max-width: 600px) {
     :root {
-        --cell-size: 75px; 
+        --cell-size: 75px;
     }
     .cell { font-size: 3.5rem; }
     #keyboard button { height: 50px; }
@@ -332,6 +338,9 @@ body {
     }
     #difficulty-buttons .difficulty-button {
         width: 80%;
+    }
+    #game-logo {
+        width: 100px;
     }
 }
 


### PR DESCRIPTION
## Summary
- rebrand HTML Crossword as **4DOWN**
- add 4DOWN favicon
- show 4DOWN logo above the puzzle
- tweak styles for the new logo and mobile layout
- update share text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f7a99e8f8832dafac4d5e05f360dc