### PR TITLE
Move logo to separate container

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,12 @@
 
     <div id="top-bar">
         <button id="help-button" title="How to Play">?</button>
-        <img id="game-logo" src="4DOWN-small.png" alt="4DOWN logo">
         <button id="settings-button" title="Settings">⚙</button>
+    </div>
+
+    <!-- New dedicated area for the logo so it doesn't stretch the top bar -->
+    <div id="logo-container">
+        <img id="game-logo" src="4DOWN-small.png" alt="4DOWN logo">
     </div>
 
     <div id="game-container">

--- a/style.css
+++ b/style.css
@@ -46,6 +46,14 @@ body {
     box-sizing: border-box;
 }
 
+/* Container just for the logo so it doesn't enlarge the top bar */
+#logo-container {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    margin: 10px 0;
+}
+
 /* MODIFIED: New h1 styling to replace the image */
 #game-title {
     font-size: 2.5rem;
@@ -56,8 +64,9 @@ body {
 }
 
 #game-logo {
+    width: 40vw;
     max-width: 200px;
-    width: 25vw;
+    height: auto;
 }
 
 #game-container {
@@ -300,6 +309,7 @@ body {
     .win-buttons { flex-direction: row; }
     #difficulty-buttons { flex-direction: column; }
     #difficulty-buttons .difficulty-button { width: 80%; }
+    #game-logo { width: 60vw; }
 }
 
 @media (max-height: 750px) {


### PR DESCRIPTION
## Summary
- stop letting the logo expand the top bar
- add `#logo-container` wrapper for the image
- size the logo responsively on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fb11b2144832db8b02d22c8a8025d